### PR TITLE
Fix stale sensor data leaking across updates

### DIFF
--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -121,6 +121,43 @@ class TestMalformedManufacturerData:
         assert device.validate_advertisement_key(raw_data) is False
 
 
+class TestStaleDataCleared:
+    """Verify that stale sensor data from a previous update does not leak."""
+
+    def test_no_stale_entity_values_after_non_victron_packet(self) -> None:
+        """entity_values must not contain stale sensors after a non-Victron packet."""
+        device = VictronBluetoothDeviceData(DEVICES["battery_monitor"]["key"])
+        # First update succeeds
+        update1 = device.update(make_service_info("battery_monitor"))
+        assert len(update1.entity_values) > 1
+
+        # Second update has no Victron data
+        non_victron = BluetoothServiceInfo(
+            name="SmartShunt",
+            address="AA:BB:CC:DD:EE:FF",
+            rssi=-60,
+            manufacturer_data={0x0000: b"garbage"},
+            service_data={},
+            service_uuids=[],
+            source="local",
+        )
+        update2 = device.update(non_victron)
+        # Only signal_strength should remain (added by BluetoothData.update)
+        assert len(update2.entity_values) <= 1
+
+    def test_no_stale_entity_values_after_bad_key(self) -> None:
+        """entity_values must not contain stale sensors when decryption fails."""
+        good_key = DEVICES["battery_monitor"]["key"]
+        device = VictronBluetoothDeviceData(good_key)
+        update1 = device.update(make_service_info("battery_monitor"))
+        assert len(update1.entity_values) > 1
+
+        # Switch to a bad key and try again with the same advertisement
+        device._advertisement_key = "00" + good_key[2:]
+        update2 = device.update(make_service_info("battery_monitor"))
+        assert len(update2.entity_values) <= 1
+
+
 @pytest.mark.parametrize(
     "key",
     [

--- a/victron_ble_ha_parser/__init__.py
+++ b/victron_ble_ha_parser/__init__.py
@@ -1,11 +1,12 @@
 """A parser module for use by Home Assistant."""
 
 from .custom_state_data import SensorDeviceClass, Units, Keys
-from .parser import VictronBluetoothDeviceData
+from .parser import VictronBluetoothDeviceData, detect_device_type
 
 __all__ = [
     "Keys",
     "Units",
     "SensorDeviceClass",
     "VictronBluetoothDeviceData",
+    "detect_device_type",
 ]

--- a/victron_ble_ha_parser/parser.py
+++ b/victron_ble_ha_parser/parser.py
@@ -89,6 +89,14 @@ class VictronBluetoothDeviceData(BluetoothData):
         return True
 
     def _start_update(self, data: BluetoothServiceInfo) -> None:
+        # Clear per-update state to prevent stale data from a previous
+        # successful parse leaking into the current SensorUpdate when
+        # this update returns early (e.g. unsupported device, bad key).
+        self._sensor_values_updates.clear()
+        self._sensor_descriptions_updates.clear()
+        self._binary_sensor_values_updates.clear()
+        self._binary_sensor_descriptions_updates.clear()
+
         try:
             raw_data = data.manufacturer_data[VICTRON_IDENTIFIER]
         except (KeyError, IndexError):


### PR DESCRIPTION
## Problem

`SensorData._sensor_values_updates` and related dicts from the upstream `sensor-state-data` library are never cleared between `update()` calls. When `_start_update()` returns early (unsupported device type, bad key, non-Victron packet), stale `entity_values` from a previous successful parse leak into the current `SensorUpdate`.

This causes the HA integration's reauth logic to incorrectly think decryption succeeded, since it checks entity count to detect failures.

## Fix

- Clear all per-update state dicts (`_sensor_values_updates`, `_sensor_descriptions_updates`, etc.) at the start of `_start_update()` so each update accurately reflects only the current advertisement.
- Expose `detect_device_type` in the public API so the HA integration can import it from `victron_ble_ha_parser` instead of reaching into internal modules.

## Tests

Added 2 regression tests:
- Stale data cleared after a non-Victron packet
- Stale data cleared after a failed decryption (bad key)